### PR TITLE
add flag HS_FLAG_UNIX_LINES

### DIFF
--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -122,8 +122,8 @@ ParsedLitExpression::ParsedLitExpression(unsigned index_in,
                                          const char *expression,
                                          size_t expLength, unsigned flags,
                                          ReportID report)
-    : expr(index_in, false, flags & HS_FLAG_SINGLEMATCH, false, false,
-           SOM_NONE, report, 0, MAX_OFFSET, 0, 0, 0, false) {
+    : expr(index_in, false, flags & HS_FLAG_SINGLEMATCH, false, false, SOM_NONE,
+           report, 0, MAX_OFFSET, 0, 0, 0, false, flags & HS_FLAG_UNIX_LINES) {
     // For pure literal expression, below 'HS_FLAG_'s are unuseful:
     // DOTALL/ALLOWEMPTY/UTF8/UCP/PREFILTER/COMBINATION/QUIET/MULTILINE
 
@@ -154,7 +154,7 @@ ParsedExpression::ParsedExpression(unsigned index_in, const char *expression,
                                    const hs_expr_ext *ext)
     : expr(index_in, flags & HS_FLAG_ALLOWEMPTY, flags & HS_FLAG_SINGLEMATCH,
            false, flags & HS_FLAG_PREFILTER, SOM_NONE, report, 0, MAX_OFFSET,
-           0, 0, 0, flags & HS_FLAG_QUIET) {
+           0, 0, 0, flags & HS_FLAG_QUIET, flags & HS_FLAG_UNIX_LINES) {
     // We disallow SOM + Quiet.
     if ((flags & HS_FLAG_QUIET) && (flags & HS_FLAG_SOM_LEFTMOST)) {
         throw CompileError("HS_FLAG_QUIET is not supported in "

--- a/src/compiler/expression_info.h
+++ b/src/compiler/expression_info.h
@@ -46,12 +46,13 @@ public:
                    bool highlander_in, bool utf8_in, bool prefilter_in,
                    som_type som_in, ReportID report_in, u64a min_offset_in,
                    u64a max_offset_in, u64a min_length_in, u32 edit_distance_in,
-                   u32 hamm_distance_in, bool quiet_in)
+                   u32 hamm_distance_in, bool quiet_in, bool unix_lines_in)
         : index(index_in), report(report_in), allow_vacuous(allow_vacuous_in),
           highlander(highlander_in), utf8(utf8_in), prefilter(prefilter_in),
           som(som_in), min_offset(min_offset_in), max_offset(max_offset_in),
           min_length(min_length_in), edit_distance(edit_distance_in),
-          hamm_distance(hamm_distance_in), quiet(quiet_in) {}
+          hamm_distance(hamm_distance_in), quiet(quiet_in),
+          unix_lines(unix_lines_in) {}
 
     /**
      * \brief Index of the expression represented by this graph.
@@ -101,6 +102,9 @@ public:
 
     /** \brief Quiet on match. */
     bool quiet;
+
+    /** \brief Unix-only line endings pattern. (HS_FLAG_UNIX_LINES) */
+    bool unix_lines;
 };
 
 }

--- a/src/hs_compile.h
+++ b/src/hs_compile.h
@@ -1004,6 +1004,14 @@ hs_error_t HS_CDECL hs_populate_platform(hs_platform_info_t *platform);
  */
 #define HS_FLAG_QUIET           1024
 
+/**
+ * Compile flag: Unix-only line endings.
+ *
+ * When this flag is enabled, only \\u000a is recognized as a line ending
+ * in the behavior of ., ^, and $.
+ */
+#define HS_FLAG_UNIX_LINES      2048
+
 /** @} */
 
 /**

--- a/src/hs_internal.h
+++ b/src/hs_internal.h
@@ -82,7 +82,8 @@ extern "C"
                     | HS_FLAG_ALLOWEMPTY \
                     | HS_FLAG_SOM_LEFTMOST \
                     | HS_FLAG_COMBINATION \
-                    | HS_FLAG_QUIET)
+                    | HS_FLAG_QUIET \
+                    | HS_FLAG_UNIX_LINES)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/nfagraph/ng_builder.cpp
+++ b/src/nfagraph/ng_builder.cpp
@@ -83,6 +83,8 @@ public:
 
     BuiltExpression getGraph() override;
 
+    bool getHSFlagUnixLines() override;
+
 private:
     /** fetch a vertex given its Position ID. */
     NFAVertex getVertex(Position pos) const;
@@ -164,6 +166,10 @@ BuiltExpression NFABuilderImpl::getGraph() {
     }
 
     return { expr, move(graph) };
+}
+
+bool NFABuilderImpl::getHSFlagUnixLines() {
+    return expr.unix_lines;
 }
 
 void NFABuilderImpl::setNodeReportID(Position pos, int offsetAdjust) {

--- a/src/nfagraph/ng_builder.h
+++ b/src/nfagraph/ng_builder.h
@@ -87,6 +87,8 @@ public:
      * Note that this builder cannot be used after this call.
      */
     virtual BuiltExpression getGraph() = 0;
+
+    virtual bool getHSFlagUnixLines() = 0;
 };
 
 /** Construct a usable NFABuilder. */

--- a/src/parser/ComponentBoundary.cpp
+++ b/src/parser/ComponentBoundary.cpp
@@ -81,7 +81,11 @@ static
 Position makeNewline(GlushkovBuildState &bs) {
     NFABuilder &builder = bs.getBuilder();
     Position newline = builder.makePositions(1);
-    builder.addCharReach(newline, CharReach('\n'));
+    if (builder.getHSFlagUnixLines()) {
+        builder.addCharReach(newline, CharReach("\n"));
+    } else {
+        builder.addCharReach(newline, CharReach("\n\r"));
+    }
     return newline;
 }
 

--- a/src/parser/Parser.h
+++ b/src/parser/Parser.h
@@ -59,6 +59,7 @@ struct ParseMode {
     bool multiline = false;
     bool ucp = false;
     bool utf8 = false;
+    bool unix_lines = false;
 };
 
 /** \brief Parse the given regular expression into a \ref Component tree.

--- a/src/parser/Utf8ComponentClass.cpp
+++ b/src/parser/Utf8ComponentClass.cpp
@@ -104,6 +104,9 @@ CodePointSet getPredefinedCodePointSet(PredefinedClass c,
         } else {
             CodePointSet rv;
             rv.set('\n');
+            if (!mode.unix_lines) {
+                rv.set('\r');
+            }
             rv.flip();
             return rv;
         }

--- a/src/parser/buildstate.cpp
+++ b/src/parser/buildstate.cpp
@@ -234,7 +234,11 @@ static
 Position makeNewlineAssertPos(GlushkovBuildState &bs) {
     NFABuilder &builder = bs.getBuilder();
     Position newline = builder.makePositions(1);
-    builder.addCharReach(newline, CharReach('\n'));
+    if (builder.getHSFlagUnixLines()) {
+        builder.addCharReach(newline, CharReach("\n"));
+    } else {
+        builder.addCharReach(newline, CharReach("\n\r"));
+    }
     builder.setAssertFlag(newline, POS_FLAG_FIDDLE_ACCEPT);
     builder.setNodeReportID(newline, -1);
     return newline;

--- a/src/parser/parser_util.cpp
+++ b/src/parser/parser_util.cpp
@@ -43,6 +43,7 @@ ParseMode::ParseMode(u32 hs_flags) :
     ignore_space(false),
     multiline(hs_flags & HS_FLAG_MULTILINE),
     ucp(hs_flags & HS_FLAG_UCP),
-    utf8(hs_flags & HS_FLAG_UTF8) {}
+    utf8(hs_flags & HS_FLAG_UTF8),
+    unix_lines(hs_flags & HS_FLAG_UNIX_LINES) {}
 
 } // namespace ue2


### PR DESCRIPTION
When the flag  `HS_FLAG_UNIX_LINES` is enabled, only `\\u000a` is recognized as a line ending in the behavior of `.`, `^` and `$`. It behaves the same way as ICU.